### PR TITLE
Added see_new_friend API.

### DIFF
--- a/jewelbots_friendship_v121/cores/Jewelbot_v1/Jewelbots_src/LED_ColorLabel.h
+++ b/jewelbots_friendship_v121/cores/Jewelbot_v1/Jewelbots_src/LED_ColorLabel.h
@@ -1,0 +1,22 @@
+#ifndef __LED_COLORLABEL_H__
+#define __LED_COLORLABEL_H__
+
+typedef enum {
+    OFF = 0,
+    RED = 1,
+    GREEN = 2,
+    BLUE = 3,
+    YELLOW = 4,
+    MAGENTA = 5,
+    CYAN = 6,
+    WHITE = 7,
+    ORANGE = 8,
+    GOLD = 9,
+    PURPLE = 10,
+    PERIWINKLE = 11,
+    ROSE = 12,
+    OCEAN = 13,
+    SKY = 14
+} ColorLabel;
+
+#endif

--- a/jewelbots_friendship_v121/cores/Jewelbot_v1/Jewelbots_src/led_sequence.h
+++ b/jewelbots_friendship_v121/cores/Jewelbot_v1/Jewelbots_src/led_sequence.h
@@ -2,6 +2,7 @@
 #define __LED_SEQUENCE_H__
 
 #include "fsm.h"
+#include "LED_ColorLabel.h"
 #include <stdint.h>
 
 void led_indicate_error(void);
@@ -36,5 +37,7 @@ bool see_red_friends(void);
 bool see_green_friends(void);
 bool see_blue_friends(void);
 bool see_cyan_friends(void);
+
+void see_new_friend(ColorLabel friendship_color);
 
 #endif

--- a/jewelbots_friendship_v121/cores/Jewelbot_v1/LED_Colors.h
+++ b/jewelbots_friendship_v121/cores/Jewelbot_v1/LED_Colors.h
@@ -1,13 +1,10 @@
-
 #ifndef __LED_COLORS_H__
 #define __LED_COLORS_H__
 
+#include "LED_ColorLabel.h"
 
 extern "C"{
  // __cplusplus
-
-enum ColorLabel { OFF = 0, RED = 1, GREEN = 2, BLUE = 3, YELLOW = 4, MAGENTA = 5, CYAN = 6, WHITE = 7, ORANGE = 8, GOLD = 9, PURPLE = 10, PERIWINKLE = 11, ROSE = 12, OCEAN = 13, SKY = 14 };
-
 
 struct Color
 {
@@ -38,7 +35,6 @@ const Color COLORS[15] = {
   Color( 0x20, 0xB2, 0x50), // Ocean
   Color( 0x64, 0x95, 0xFA) // Sky
 };
-
 
 
 }


### PR DESCRIPTION
Coders can define a `void see_new_friend(ColorLabel friendship_color)`
which will be called when a friend enters the room. You can switch on
the friendship_color to behave differently depending on the friend's
group.

* Moved the ColorLabel enum into Jewelbots_src
* Rewrote the loop in save_arduino_colors
* Renamed some variables:
  * arduino_colors -> visible_friends
  * save_arduino_colors -> save_visible_friends
  * renamed locals in save_visible_friends